### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-calculator.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-calculator.spec
+    - .packit.yaml
+
+upstream_package_name: deepin-calculator
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-calculator
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"0,/Version:/ s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-calculator.spec"

--- a/rpm/deepin-calculator.spec
+++ b/rpm/deepin-calculator.spec
@@ -1,0 +1,47 @@
+Name:           deepin-calculator
+Version:        5.6.0.7
+Release:        1%{?dist}
+Summary:        An easy to use calculator for ordinary users
+License:        GPLv3
+URL:            https://github.com/linuxdeepin/deepin-calculator
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  qt5-linguist
+BuildRequires:  cmake
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5Gui)
+BuildRequires:  pkgconfig(Qt5Widgets)
+BuildRequires:  pkgconfig(Qt5Svg)
+BuildRequires:  pkgconfig(dtkwidget) >= 2.0
+BuildRequires:  pkgconfig(Qt5Multimedia)
+BuildRequires:  pkgconfig(Qt5X11Extras)
+BuildRequires:  pkgconfig(dframeworkdbus)
+BuildRequires:  desktop-file-utils
+Requires:       hicolor-icon-theme
+
+%description
+%{summary}.
+
+%prep
+%autosetup -p1
+sed -i 's|59 Temple Place, Suite 330|51 Franklin Street, Fifth Floor|;
+        s|Boston, MA 02111-1307 USA.|Boston, MA 02110-1335, USA.|' src/math/*.{c,h}
+
+%build
+%cmake
+%cmake_build
+
+%install
+%cmake_install
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log: Initial packit setup
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>