### PR TITLE
fix cmake typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Deepin calculator is an easy to use calculator for ordinary users.
 
 * mkdir build
 * cd build
-* qmake ..
+* cmake ..
 * make
 
 ## Usage


### PR DESCRIPTION
cmake错写成了qmake，qmake无法使用，需要使用cmake编译