### PR TITLE
Fix: integer overflow in '_setstr' functions.

### DIFF
--- a/3rdparty/math/floatio.c
+++ b/3rdparty/math/floatio.c
@@ -79,10 +79,21 @@ _setstr(
   {
     if (src == NULL)
       *(dest->buf) = '\0';
-    else if (dest->sz < (int)strlen(src) + 1)
-      return 0;
     else
-      strcpy(dest->buf, src);
+    {
+      size_t src_len = strlen(src);
+      
+      // Check for integer overflow
+      if (src_len == SIZE_MAX)
+      {
+        return 0;
+      }
+      
+      if (dest->sz < src_len + 1)
+        return 0;
+      else
+        strcpy(dest->buf, src);
+    }
   }
   return 1;
 }

--- a/3rdparty/math/floatio.c
+++ b/3rdparty/math/floatio.c
@@ -32,6 +32,7 @@
 #include "floatio.h"
 #include "floatlong.h"
 #include <string.h>
+#include <stdint.h>
 
 typedef enum { NmbNormal, NmbSpecial, NmbBufferOverflow } NmbType;
 


### PR DESCRIPTION
 In the original function, the strlen() function is used to calculate the length of the src string, and the result is cast to int type and 1 is added. This type conversion may lead to integer overflow, especially when the length of the src string is close to 'INT_MAX', adding one may become a negative number, causing the judgment condition that should be judged to be too long to be invalid, resulting in the risk of overflow . The modified function removes the forced type conversion, and adds the judgment of 'SIZE_MAX', eliminating the risk of integer overflow. 