### PR TITLE
fix: 修复了计算器UI 按钮间隔不一致的问题

### DIFF
--- a/src/control/basickeypad.cpp
+++ b/src/control/basickeypad.cpp
@@ -11,12 +11,14 @@
 
 #include "dthememanager.h"
 
-const int KEYPAD_HEIGHT = 316; //键盘界面高度
-const int KEYPAD_SPACING = 3; //键盘按键间距,按钮比ui大2pix,此处小2pix
+const QSize STANDARD_TEXTBTNSIZE = QSize(79, 58); //标准模式按钮大小，为画边框比ui大2pix
+const int STANDARD_WIDTH = 352; //标准模式宽度
+const int KEYPAD_SPACING = 4; //键盘按键间距
+const int KEYPAD_HEIGHT = STANDARD_TEXTBTNSIZE.height() * 5 + KEYPAD_SPACING * 4; //键盘界面高度, 306
+const int KEYPAD_WIDTH = STANDARD_TEXTBTNSIZE.width() * 4 + KEYPAD_SPACING * 3; //键盘界面宽度, 328
 const int LEFT_MARGIN = 12; //键盘左边距
-const int RIGHT_MARGIN = 13; //键盘右边距
-const int BOTTOM_MARGIN = 11; //键盘下边距
-const QSize STANDARD_TEXTBTNSIZE = QSize(78, 58); //标准模式按钮大小，为画边框比ui大2pix
+//const int RIGHT_MARGIN = 12; //键盘右边距
+//const int BOTTOM_MARGIN = 11; //键盘下边距
 
 const BasicKeypad::KeyDescription BasicKeypad::keyDescriptions[] = {
 //    {"MC", Key_MC, 1, 0, 1, 2},       {"MR", Key_MR, 1, 2, 1, 2},
@@ -68,12 +70,14 @@ const BasicKeypad::KeyDescription BasicKeypad::keyDescriptions[] = {
 
 BasicKeypad::BasicKeypad(QWidget *parent)
     : DWidget(parent),
-      m_layout(new QGridLayout(this)),
+      //m_layout(new QGridLayout(this)),
       m_mapper(new QSignalMapper(this))
 {
-    this->setFixedHeight(KEYPAD_HEIGHT);
+    QWidget* grid_container = new QWidget(this);
+    grid_container->setGeometry(LEFT_MARGIN, 0, KEYPAD_WIDTH, KEYPAD_HEIGHT);
+    grid_container->setFixedSize(KEYPAD_WIDTH, KEYPAD_HEIGHT);
+    m_layout = new QGridLayout(grid_container);
     m_layout->setMargin(0);
-    m_layout->setSpacing(KEYPAD_SPACING);
     m_layout->setContentsMargins(0, 0, 0, 0);
 //    setFocusPolicy(Qt::StrongFocus);
 
@@ -172,9 +176,8 @@ void BasicKeypad::initButtons()
             }
         }
 
-        button->setFixedSize(STANDARD_TEXTBTNSIZE);
-        m_layout->addWidget(button, desc->row, desc->column, desc->rowcount, desc->columncount,
-                            Qt::AlignHCenter | Qt::AlignVCenter);
+        button->setMaximumSize(STANDARD_TEXTBTNSIZE);
+        m_layout->addWidget(button, desc->row, desc->column, desc->rowcount, desc->columncount);
         const QPair<DPushButton *, const KeyDescription *> hashValue(button, desc);
         m_keys.insert(desc->button, hashValue); //key为枚举值，value.first为DPushButton *, value.second为const KeyDescription *
 
@@ -197,7 +200,10 @@ void BasicKeypad::initUI()
     button(Key_Min)->setObjectName("SymbolButton");
     button(Key_Plus)->setObjectName("SymbolButton");
 
-    this->setContentsMargins(LEFT_MARGIN, 0, RIGHT_MARGIN, BOTTOM_MARGIN);
+    m_layout->setVerticalSpacing(KEYPAD_SPACING);
+    m_layout->setHorizontalSpacing(KEYPAD_SPACING);
+
+    //this->setContentsMargins(LEFT_MARGIN, 0, RIGHT_MARGIN, BOTTOM_MARGIN);
 }
 
 /**

--- a/src/control/memhiskeypad.cpp
+++ b/src/control/memhiskeypad.cpp
@@ -23,7 +23,7 @@ MemHisKeypad::MemHisKeypad(QWidget *parent)
     m_layout->setContentsMargins(0, 0, 0, 0);
 
     initButtons();
-    this->setContentsMargins(12, 0, 13, 0);
+    this->setContentsMargins(12, 0, 12, 0);
 
     connect(m_mapper, SIGNAL(mapped(int)), SIGNAL(buttonPressed(int)));
 }

--- a/src/control/memorykeypad.cpp
+++ b/src/control/memorykeypad.cpp
@@ -5,7 +5,7 @@
 
 #include "memorykeypad.h"
 
-const QSize MEMORYBUTTON_SIZE = QSize(52, 32); //标准模式大小，为画边框比ui大2pix
+const QSize MEMORYBUTTON_SIZE = QSize(53, 32); //标准模式大小，为画边框比ui大2pix
 
 const MemoryKeypad::KeyDescription MemoryKeypad::keyDescriptions[] = {
     {"MC", Key_MC, 1, 0, 1, 1},       {"MR", Key_MR, 1, 1, 1, 1},
@@ -24,7 +24,7 @@ MemoryKeypad::MemoryKeypad(QWidget *parent)
     m_layout->setContentsMargins(0, 0, 0, 0);
 
     initButtons();
-    this->setContentsMargins(12, 0, 13, 0);
+    this->setContentsMargins(12, 0, 12, 0);
 
     connect(m_mapper, SIGNAL(mapped(int)), SIGNAL(buttonPressed(int)));
 }

--- a/src/control/procheckbtnkeypad.cpp
+++ b/src/control/procheckbtnkeypad.cpp
@@ -20,11 +20,11 @@ ProCheckBtnKeypad::ProCheckBtnKeypad(QWidget *parent)
 {
     this->setFixedHeight(45);
     m_layout->setMargin(0);
-    m_layout->setSpacing(2);  //按钮比ui大2pix,此处比ui小2pix
+    m_layout->setSpacing(3);  //按钮比ui大2pix,此处比ui小2pix
     m_layout->setContentsMargins(0, 0, 0, 0);
 
     initButtons();
-    this->setContentsMargins(10, 0, 10, 0);
+    this->setContentsMargins(12, 0, 12, 0);
 
     connect(m_mapper, SIGNAL(mapped(int)), SIGNAL(buttonPressed(int)));
 }

--- a/src/control/programmerkeypad.cpp
+++ b/src/control/programmerkeypad.cpp
@@ -5,12 +5,13 @@
 
 #include "programmerkeypad.h"
 
-const int KEYPAD_HEIGHT = 279; //键盘界面高度
-const int KEYPAD_SPACING = 3; //键盘按键间距,按钮比ui大2pix,此处小2pix
-const int LEFT_MARGIN = 10; //键盘左边距,按钮比ui大2pix,此处小2pix
-const int RIGHT_MARGIN = 10; //键盘右边距,按钮比ui大2pix,此处小2pix
-const int BOTTOM_MARGIN = 10; //键盘下边距,按钮比ui大2pix,此处小2pix
 const QSize STANDARD_TEXTBTNSIZE = QSize(69, 42); //程序员模式按钮大小，为画边框比ui大2pix
+const int KEYPAD_HEIGHT = 267; //键盘界面高度
+const int KEYPAD_WIDTH = 429; //键盘界面高度
+const int KEYPAD_SPACING = 3; //键盘按键间距,按钮比ui大2pix,此处小2pix
+const int LEFT_MARGIN = 12; //键盘左边距,按钮比ui大2pix,此处小2pix
+//const int RIGHT_MARGIN = 12; //键盘右边距,按钮比ui大2pix,此处小2pix
+//const int BOTTOM_MARGIN = 10; //键盘下边距,按钮比ui大2pix,此处小2pix
 
 const ProgrammerKeypad::KeyDescription ProgrammerKeypad::keyDescriptions[] = {
     {"AND", Key_AND, 0, 0},         {"A", Key_A, 0, 1},             {"<<", Key_moveL, 0, 2},
@@ -34,14 +35,18 @@ const ProgrammerKeypad::KeyDescription ProgrammerKeypad::keyDescriptions[] = {
 
 ProgrammerKeypad::ProgrammerKeypad(QWidget *parent)
     : DWidget(parent),
-      m_layout(new QGridLayout(this)),
+      //m_layout(new QGridLayout(this)),
       m_mapper(new QSignalMapper(this)),
       m_leftBracket(new DLabel(this)),
       m_rightBracket(new DLabel(this))
 {
-    this->setFixedHeight(KEYPAD_HEIGHT);
+    QWidget* grid_container = new QWidget(this);
+    grid_container->setGeometry(LEFT_MARGIN, 0, KEYPAD_WIDTH, KEYPAD_HEIGHT);
+    grid_container->setFixedSize(KEYPAD_WIDTH, KEYPAD_HEIGHT);
+    m_layout = new QGridLayout(grid_container);
+
+
     m_layout->setMargin(0);
-    m_layout->setSpacing(KEYPAD_SPACING);
     m_layout->setContentsMargins(0, 0, 0, 0);
 //    setFocusPolicy(Qt::StrongFocus);
     m_leftBracket->setFixedSize(24, 14);
@@ -151,10 +156,10 @@ void ProgrammerKeypad::initButtons()
         }
 
         if (desc->text == "=")
-            button->setFixedSize(69, 43);
+            button->setMaximumSize(69, 43);
         else
-            button->setFixedSize(STANDARD_TEXTBTNSIZE);
-        m_layout->addWidget(button, desc->row, desc->column, Qt::AlignHCenter | Qt::AlignVCenter);
+            button->setMaximumSize(STANDARD_TEXTBTNSIZE);
+        m_layout->addWidget(button, desc->row, desc->column);
         const QPair<DPushButton *, const KeyDescription *> hashValue(button, desc);
         m_keys.insert(desc->button, hashValue); //key为枚举值，value.first为DPushButton *, value.second为const KeyDescription *
 
@@ -365,5 +370,8 @@ void ProgrammerKeypad::initUI()
     button(Key_Min)->setObjectName("SymbolButton");
     button(Key_Plus)->setObjectName("SymbolButton");
 
-    this->setContentsMargins(LEFT_MARGIN, 0, RIGHT_MARGIN, BOTTOM_MARGIN);
+    m_layout->setVerticalSpacing(3);
+    m_layout->setHorizontalSpacing(3);
+
+    //this->setContentsMargins(LEFT_MARGIN, 0, RIGHT_MARGIN, BOTTOM_MARGIN);
 }

--- a/src/control/prosystemkeypad.cpp
+++ b/src/control/prosystemkeypad.cpp
@@ -8,8 +8,8 @@
 #include <QDebug>
 #include "../../3rdparty/core/settings.h"
 
-const QSize SYSTEMKEYPADSIZE = QSize(451, 279);
-const int LEFT_MARGIN = 10; //键盘左边距
+const QSize SYSTEMKEYPADSIZE = QSize(453, 279);
+const int LEFT_MARGIN = 12; //键盘左边距
 const int BOTTOM_MARGIN = 14; //键盘下边距
 
 ProSystemKeypad::ProSystemKeypad(QWidget *parent)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,9 +25,9 @@
 
 DGUI_USE_NAMESPACE
 
-const QSize STANDARD_SIZE = QSize(344, 545); //标准模式的固定大小
-const QSize SCIENTIFIC_MIN_SIZE = QSize(451, 542); //科学模式的最小size
-const QSize PROGRAMM_SIZE = QSize(451, 574); //程序员模式固定大小
+const QSize STANDARD_SIZE = QSize(352, 548); //标准模式的固定大小
+const QSize SCIENTIFIC_MIN_SIZE = QSize(453, 542); //科学模式的最小size
+const QSize PROGRAMM_SIZE = QSize(453, 574); //程序员模式固定大小
 
 MainWindow::MainWindow(QWidget *parent)
     : DMainWindow(parent)

--- a/src/views/memorywidget.cpp
+++ b/src/views/memorywidget.cpp
@@ -26,8 +26,8 @@
 const int STANDARD_MWIDGET_HEIGHT = 260; //标准模式memorywidget高度
 const int SCIENTIFIC_MWIDGET_HEIGHT = 302; //科学模式memorywidget高度
 const int PROGRAMMER_MWIDGET_HEIGHT = 230; //程序猿模式memorywidget高度
-const int STANDARD_ITEM_WIDTH = 344; //标准模式宽度
-const int PRO_SCI_ITEM_WIDTH = 451; //科学-程序猿模式最小宽度
+const int STANDARD_ITEM_WIDTH = 352; //标准模式宽度
+const int PRO_SCI_ITEM_WIDTH = 453; //科学-程序猿模式最小宽度
 const int STANDARD_FORMAT_PREC = 15; //标准模式科学计数位数
 const int SCIENTIFIC_FORMAT_PREC = 31; //科学模式科学计数位数
 const int MAXSIZE = 500; //内存保存最大数

--- a/src/widgets/programmodule.cpp
+++ b/src/widgets/programmodule.cpp
@@ -41,7 +41,7 @@ ProgramModule::ProgramModule(QWidget *parent)
     m_stackWidget->addWidget(m_proSystemKeypad);
     m_stackWidget->addWidget(m_memorylistwidget);
     m_stackWidget->setCurrentWidget(m_programmerKeypad);
-    m_stackWidget->setFixedSize(451, 279);
+    m_stackWidget->setFixedSize(453, 279);
 
     initArrowRectangle();
 


### PR DESCRIPTION
[原issue:](https://github.com/linuxdeepin/developer-center/issues/4124)
由于原代码的按钮区域大未正确设置，且按钮设置为固定大小，而 QGridLayout会自动调整，导致按钮间隔不一致。 现在略微修改一些Widget和按钮宽度，将按钮大小调整为用setMaximumSize或setMinimumSize设置,使得各模式下按钮布局间隔均一致。
修改前后对比(左图为修改后效果):
![截图_选择区域_20230419195126](https://user-images.githubusercontent.com/44284163/233066848-1d5ada41-8105-4c68-b673-cccd67ed4924.png)
标准模式最明显
![截图_选择区域_20230419195157](https://user-images.githubusercontent.com/44284163/233066956-95ce821f-8a17-4ef0-9a29-b3ff76e5ab08.png)
科学模式
![截图_选择区域_20230419195233](https://user-images.githubusercontent.com/44284163/233067073-429b7df9-7313-4ce6-9896-bc0a8905e77f.png)
程序员模式

 整体布局更加和谐，特别是标准模式、科学模式。


