### PR TITLE
fix: 修复了一系列build warning

### DIFF
--- a/3rdparty/core/evaluator.cpp
+++ b/3rdparty/core/evaluator.cpp
@@ -595,7 +595,7 @@ void TokenStack::reduce(QList<Token> tokens, Token &&top, int minPrecedence)
     }
 #endif // EVALUATOR_DEBUG
 
-    qSort(tokens.begin(), tokens.end(), tokenPositionCompare);
+    std::sort(tokens.begin(), tokens.end(), tokenPositionCompare);
 
     bool computeMinPrec = (minPrecedence == INVALID_PRECEDENCE);
     int min_prec = computeMinPrec ? MAX_PRECEDENCE : minPrecedence;

--- a/3rdparty/core/evaluator.h
+++ b/3rdparty/core/evaluator.h
@@ -65,7 +65,7 @@ public:
 
     static const Token null;
 
-    Token(Type = stxUnknown, const QString & = QString::null, int pos = -1,
+    Token(Type = stxUnknown, const QString & = QString(), int pos = -1,
           int size = -1);
     Token(const Token &);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
     DGuiApplicationHelper::ColorType oldpalette = getThemeTypeSetting();
     DApplicationSettings savetheme(&app);
     if (oldversion == true) {
-        DGuiApplicationHelper::instance()->setThemeType(oldpalette);
+        DGuiApplicationHelper::instance()->setPaletteType(oldpalette);
     }
 
     // 20200330 主题记忆更改为规范代码

--- a/src/views/memorywidget.cpp
+++ b/src/views/memorywidget.cpp
@@ -341,7 +341,7 @@ QString MemoryWidget::programmerWrap(QString result)
         block = 4;
 
     while (r < result.length()) {
-        if (fm.width(result.mid(l, r - l)) < validwidth)
+        if (fm.horizontalAdvance(result.mid(l, r - l)) < validwidth)
             ++r;
         else {
             while (result.at(r) != QLatin1String(" ") && result.at(r) != QLatin1String(",")) {

--- a/src/views/simplelistdelegate.cpp
+++ b/src/views/simplelistdelegate.cpp
@@ -11,6 +11,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <DGuiApplicationHelper>
+#include <QtGlobal>
 
 #include "dthememanager.h"
 #include "simplelistmodel.h"
@@ -148,7 +149,7 @@ void SimpleListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
             font.setPixelSize(i);
 
             QFontMetrics fm(font);
-            int fontWidth = fm.width(expression);
+            int fontWidth = fm.horizontalAdvance(expression);
             int editWidth = rect.width() - 24;
 
             if (fontWidth < editWidth)
@@ -158,12 +159,12 @@ void SimpleListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
 
         QStringList splitList = expression.split("＝");
         QString resultStr = splitList.last();
-        int resultWidth = painter->fontMetrics().width(resultStr);
+        int resultWidth = painter->fontMetrics().horizontalAdvance(resultStr);
 
         if (resultWidth > rect.width() / 1.4) {
             resultStr = painter->fontMetrics().elidedText(resultStr, Qt::ElideRight,
                                                           int(rect.width() / 1.4) + PADDING);
-            resultWidth = painter->fontMetrics().width(resultStr);
+            resultWidth = painter->fontMetrics().horizontalAdvance(resultStr);
         }
 
         if (m_type == 1) {
@@ -187,7 +188,7 @@ void SimpleListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
             }
         }
 
-        int equalStrWidth = painter->fontMetrics().width(" ＝ ");
+        int equalStrWidth = painter->fontMetrics().horizontalAdvance(" ＝ ");
         QString expStr = painter->fontMetrics().elidedText(
                              splitList.first(), Qt::ElideLeft, rect.width() - resultWidth - PADDING * 2 - equalStrWidth);
         // QString expStr = splitList.first();
@@ -247,7 +248,7 @@ void SimpleListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
                     painter->setPen(QColor(linkColor)); //判断第一个数是否是被联动项,如果是，设置字体颜色为高亮
             }
 
-            int expWidth = painter->fontMetrics().width(exp);
+            int expWidth = painter->fontMetrics().horizontalAdvance(exp);
             painter->drawText(QRect(rect.x() + PADDING, rect.y(),
                                     rect.width() - resultWidth - expWidth - PADDING * 2, rect.height()),
                               Qt::AlignVCenter | Qt::AlignRight, linkNum);
@@ -276,9 +277,9 @@ void SimpleListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
         QString exp = splitList.first() + " ＝ ";
 
         int expHeight;
-        int expline = (painter->fontMetrics().width(exp) % (rect.width() - PADDING * 2)) ?
-                      (painter->fontMetrics().width(exp) / (rect.width() - PADDING * 2) + 1) :
-                      (painter->fontMetrics().width(exp) / (rect.width() - PADDING * 2));
+        int expline = (painter->fontMetrics().horizontalAdvance(exp) % (rect.width() - PADDING * 2)) ?
+                      (painter->fontMetrics().horizontalAdvance(exp) / (rect.width() - PADDING * 2) + 1) :
+                      (painter->fontMetrics().horizontalAdvance(exp) / (rect.width() - PADDING * 2));
         expHeight = painter->fontMetrics().height() * expline;
 
         if (m_type == 1) {
@@ -317,9 +318,9 @@ void SimpleListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
                 exp, textoption); //exp与上方空隙5pix
             painter->setFont(fontresult);
             int resultHeight;
-            int resultline = (painter->fontMetrics().width(resultStr) % (rect.width() - PADDING * 2 - 1)) ?
-                             (painter->fontMetrics().width(resultStr) / (rect.width() - PADDING * 2 - 1) + 1) :
-                             (painter->fontMetrics().width(resultStr) / (rect.width() - PADDING * 2 - 1)); //由于结果字体较大，暂以此避免
+            int resultline = (painter->fontMetrics().horizontalAdvance(resultStr) % (rect.width() - PADDING * 2 - 1)) ?
+                             (painter->fontMetrics().horizontalAdvance(resultStr) / (rect.width() - PADDING * 2 - 1) + 1) :
+                             (painter->fontMetrics().horizontalAdvance(resultStr) / (rect.width() - PADDING * 2 - 1)); //由于结果字体较大，暂以此避免
             resultHeight = painter->fontMetrics().height() * resultline;
             if (resultStr == tr("Expression error")) {
                 painter->setPen(QColor(errorFontColor));
@@ -388,14 +389,14 @@ QSize SimpleListDelegate::sizeHint(const QStyleOptionViewItem &option,
         fontresult.setPixelSize(30);
         QFontMetrics fmresult(fontresult);
         int expHeight;
-        int expline = (fmexp.width(exp) % (rectwidth - PADDING * 2)) ?
-                      (fmexp.width(exp) / (rectwidth - PADDING * 2) + 1) :
-                      (fmexp.width(exp) / (rectwidth - PADDING * 2));
+        int expline = (fmexp.horizontalAdvance(exp) % (rectwidth - PADDING * 2)) ?
+                      (fmexp.horizontalAdvance(exp) / (rectwidth - PADDING * 2) + 1) :
+                      (fmexp.horizontalAdvance(exp) / (rectwidth - PADDING * 2));
         expHeight = fmexp.height() * expline;
         int resultHeight;
-        int resultline = (fmresult.width(resultStr) % (rectwidth - PADDING * 2 - 1)) ?
-                         (fmresult.width(resultStr) / (rectwidth - PADDING * 2 - 1) + 1) :
-                         (fmresult.width(resultStr) / (rectwidth - PADDING * 2 - 1)); //由于结果字体较大，暂以此避免
+        int resultline = (fmresult.horizontalAdvance(resultStr) % (rectwidth - PADDING * 2 - 1)) ?
+                         (fmresult.horizontalAdvance(resultStr) / (rectwidth - PADDING * 2 - 1) + 1) :
+                         (fmresult.horizontalAdvance(resultStr) / (rectwidth - PADDING * 2 - 1)); //由于结果字体较大，暂以此避免
         resultHeight = fmresult.height() * resultline;
         return QSize(HISWIDTH, expHeight + resultHeight + 25); //多出25pix空隙
     } else
@@ -424,7 +425,11 @@ void SimpleListDelegate::cutApart(const QString text, QString &linkNum, QString 
 {
     QString exp = text;
     QStringList list;
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     list = exp.split(QRegExp("[＋－×÷/()]"), QString::SkipEmptyParts);
+#else
+    list = exp.split(QRegularExpression("[＋－×÷/()]"), Qt::SkipEmptyParts);
+#endif
     if (list.isEmpty() || list.size() == 1) {
         linkNum = "";
         expStr = exp;

--- a/src/widgets/expressionbar.cpp
+++ b/src/widgets/expressionbar.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QTimer>
 #include <DGuiApplicationHelper>
+#include <QtGlobal>
 
 const int STANDPREC = 15;
 const int WIDGET_FIXHEIGHT = 147;
@@ -984,7 +985,11 @@ void ExpressionBar::revisionResults(const QModelIndex &index)
 {
     clearLinkageCache(m_inputEdit->text(), false);
     QString text = index.data(SimpleListModel::ExpressionRole).toString();
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     QStringList historic = text.split(QString("＝"), QString::SkipEmptyParts);
+#else
+    QStringList historic = text.split("＝", Qt::SkipEmptyParts);
+#endif
     if (historic.size() != 2)
         return;
     QString expression = historic.at(0);

--- a/src/widgets/inputedit.cpp
+++ b/src/widgets/inputedit.cpp
@@ -369,7 +369,7 @@ void InputEdit::autoZoomFontSize()
         font.setPixelSize(i);
 
         QFontMetrics fm(font);
-        int fontWidth = fm.width(text());
+        int fontWidth = fm.horizontalAdvance(text());
         int editWidth = width() - 45;
 
         if (fontWidth < editWidth)

--- a/src/widgets/proexpressionbar.cpp
+++ b/src/widgets/proexpressionbar.cpp
@@ -905,7 +905,11 @@ void ProExpressionBar::initTheme(int type)
 void ProExpressionBar::revisionResults(const QModelIndex &index)
 {
     QString text = index.data(SimpleListModel::ExpressionRole).toString();
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     QStringList historic = text.split(QString("＝"), QString::SkipEmptyParts);
+#else
+    QStringList historic = text.split("＝", Qt::SkipEmptyParts);
+#endif
     if (historic.size() != 2)
         return;
     QString expression = historic.at(0);

--- a/src/widgets/scientificmodule.cpp
+++ b/src/widgets/scientificmodule.cpp
@@ -15,6 +15,7 @@
 #include <QPainter>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QtGlobal>
 
 const int EXPRESSIONBAR_HEIGHT = 100;
 
@@ -1086,7 +1087,11 @@ void scientificModule::hideMemHisWidget()
 void scientificModule::clickListView(const QModelIndex &index)
 {
     QString text = index.data(SimpleListModel::ExpressionWithOutTip).toString();
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     QStringList historic = text.split(QString("＝"), QString::SkipEmptyParts);
+#else
+    QStringList historic = text.split("＝", Qt::SkipEmptyParts);
+#endif
     //历史记录中无内容不继续执行
     if (historic.size() != 2)
         return;

--- a/src/widgets/sciexpressionbar.cpp
+++ b/src/widgets/sciexpressionbar.cpp
@@ -14,6 +14,8 @@
 #include <QDebug>
 #include <QTimer>
 #include <DGuiApplicationHelper>
+#include <QRandomGenerator>
+#include <QtGlobal>
 
 const int SCIPREC = 31; //科学计算器精度
 const int LIST_HEIGHT = 35; //输入栏上方表达式的高度
@@ -571,8 +573,9 @@ void SciExpressionBar::enterRandEvent()
     m_isResult = false;
     m_isUndo = false;
     QString str;
+    QRandomGenerator* randGen = QRandomGenerator::system();
     for (int i = 0; i < SCIPREC; i++) {
-        int n = qrand() % 10;
+        int n = randGen->generate() % 10;
         str.append(QString::number(n));
     }
     str = "0." + str;
@@ -1095,7 +1098,11 @@ void SciExpressionBar::revisionResults(const QModelIndex &index)
 {
 //    clearLinkageCache(m_inputEdit->text(), false);
     QString text = index.data(SimpleListModel::ExpressionRole).toString();
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     QStringList historic = text.split(QString("＝"), QString::SkipEmptyParts);
+#else
+    QStringList historic = text.split("＝", Qt::SkipEmptyParts);
+#endif
     if (historic.size() != 2)
         return;
     QString expression = historic.at(0);


### PR DESCRIPTION
将已弃用的调用qsort()换成std::sort()、qrand()换用QRandomGenerator、setThemeType()换成setPaletteType()、QFontMetrics::width()换成QFontMetrics::horizontalAdvance()；将已弃用的写法QString::null换成QString()；将QString::split()的已弃用参数列表更新。