### PR TITLE
chore: Bump version to 6.5.11

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.10.1
+  version: 6.5.11.1
   kind: app
   description: |
     Calculator for UOS

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-calculator (6.5.11) unstable; urgency=medium
+
+  * Update translations.
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 09:38:24 +0800
+
 deepin-calculator (6.5.10) unstable; urgency=medium
 
   * chore: New version 6.5.10.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.10.1
+  version: 6.5.11.1
   kind: app
   description: |
     Calculator for UOS

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.10.1
+  version: 6.5.11.1
   kind: app
   description: |
     Calculator for UOS


### PR DESCRIPTION
Bump version to 6.5.11

Log: Bump version to 6.5.11

## Summary by Sourcery

Chores:
- Bump version number in linglong.yaml files for arm64, loong64, and main configurations