### PR TITLE
fix: test CI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,6 +144,13 @@ int main(int argc, char *argv[])
     DGuiApplicationHelper::ColorType oldpalette = getThemeTypeSetting();
     qInfo() << QObject::tr("Current theme type:") << oldpalette;
 
+    qDebug() << QObject::tr("Testing translations with longer sentences");
+    qDebug() << QObject::tr("This is a calculator application that supports basic arithmetic operations");
+    qDebug() << QObject::tr("Scientific mode provides advanced mathematical functions and constants");
+    qDebug() << QObject::tr("Programmer mode offers binary, octal, decimal and hexadecimal calculations");
+    qDebug() << QObject::tr("History view shows all previous calculations and their results");
+    qDebug() << QObject::tr("Memory functions allow you to store and recall calculation results");
+
 
 
     if (oldversion == true) {

--- a/translations/deepin-calculator.ts
+++ b/translations/deepin-calculator.ts
@@ -216,6 +216,30 @@
         <source>Current theme type:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Testing translations with longer sentences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is a calculator application that supports basic arithmetic operations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scientific mode provides advanced mathematical functions and constants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Programmer mode offers binary, octal, decimal and hexadecimal calculations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>History view shows all previous calculations and their results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Memory functions allow you to store and recall calculation results</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SciExpressionBar</name>


### PR DESCRIPTION
## Summary by Sourcery

Add dummy translation strings and corresponding debug log statements to test translation extraction in the CI pipeline.

CI:
- Add sample translation messages for long sentences to deepin-calculator.ts
- Inject qDebug() calls in main.cpp to exercise new translation keys during runtime