### PR TITLE
chore(version): bump version to 6.5.15

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     Calculator for UOS

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-calculator (6.5.15) unstable; urgency=medium
+
+  * bump version to 6.5.15
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 18 Jun 2025 17:51:56 +0800
+
 deepin-calculator (6.5.14) unstable; urgency=medium
 
   * chore: Update deepin-calculator version to 6.5.13.1 in configuration files

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     Calculator for UOS

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     Calculator for UOS


### PR DESCRIPTION
## Summary by Sourcery

Bump deepin-calculator version to 6.5.15.1 across all platform manifests and update the Debian changelog

Chores:
- Update version in ARM64, default, and Loong64 YAML manifests from 6.5.14.1 to 6.5.15.1
- Refresh Debian changelog to reflect the new 6.5.15.1 release