### PR TITLE
fix: Fix the issue of not being able to delete in programmer mode

### DIFF
--- a/src/widgets/proexpressionbar.cpp
+++ b/src/widgets/proexpressionbar.cpp
@@ -245,7 +245,7 @@ void ProExpressionBar::enterSymbolEvent(const QString &text)
 void ProExpressionBar::enterBackspaceEvent()
 {
     qDebug() << "enterBackspaceEvent called";
-    QString sRegNum = "[a-zA-Z0-9]";  // 匹配字母和数字
+    QString sRegNum = "[a-z]";  // 匹配字母和数字
     QRegularExpression rx;
     rx.setPattern(sRegNum);
 


### PR DESCRIPTION
Fix the issue of not being able to delete in programmer mode

Log: Fix the issue of not being able to delete in programmer mode
bug: https://pms.uniontech.com/bug-view-314599.html

## Summary by Sourcery

Restore backspace deletion in programmer mode by adding a fallback branch for removing the last character and correctly repositioning the cursor

Bug Fixes:
- Enable deletion of the last character when not within a recognized function in the ProExpressionBar
- Adjust cursor position after generic backspace deletion to account for separators