### PR TITLE
chore: Update linglong base and runtime

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     Calculator for UOS
@@ -15,8 +15,8 @@ package:
 command:
   - deepin-calculator
 
-base: org.deepin.base/25.2.0/arm64
-runtime: org.deepin.runtime.dtk/25.2.0/arm64
+base: org.deepin.base/25.2.1/arm64
+runtime: org.deepin.runtime.dtk/25.2.1/arm64
 
 build: |
   bash ./install_dep linglong/sources "$PREFIX"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-calculator (6.5.26) unstable; urgency=medium
+
+  * chore: Update linglong base and runtime
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 17 Sep 2025 10:18:11 +0800
+
 deepin-calculator (6.5.25) unstable; urgency=medium
 
   * Update version to 6.5.25. 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     Calculator for UOS
@@ -15,8 +15,8 @@ package:
 command:
   - deepin-calculator
 
-base: org.deepin.base/25.2.0/x86_64
-runtime: org.deepin.runtime.dtk/25.2.0/x86_64
+base: org.deepin.base/25.2.1/x86_64
+runtime: org.deepin.runtime.dtk/25.2.1/x86_64
 
 build: |
   bash ./install_dep linglong/sources "$PREFIX"

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     Calculator for UOS
@@ -15,8 +15,8 @@ package:
 command:
   - deepin-calculator
 
-base: org.deepin.base/25.2.0/loong64
-runtime: org.deepin.runtime.dtk/25.2.0/loong64
+base: org.deepin.base/25.2.1/loong64
+runtime: org.deepin.runtime.dtk/25.2.1/loong64
 
 build: |
   bash ./install_dep linglong/sources "$PREFIX"


### PR DESCRIPTION
Update linglong base and runtime

Log: Update linglong base and runtime

## Summary by Sourcery

Update linglong YAML manifests and Debian changelog to use the new application version and refreshed base/runtime dependencies.

Enhancements:
- Bump deepin-calculator version from 6.5.25.1 to 6.5.26.1 in all linglong package specs
- Update base and runtime references from 25.2.0 to 25.2.1 for arm64, x86_64, and loong64

Chores:
- Refresh Debian changelog entry for the new version