### PR TITLE
chore: Update version to 6.5.33

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     Calculator for UOS

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-calculator (6.5.33) unstable; urgency=medium
+
+  * fix: Fix build fail for invalid compiler flags
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 29 Jan 2026 09:21:04 +0800
+
 deepin-calculator (6.5.32) unstable; urgency=medium
 
   * chore: Update compiler flags for security enhancements

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     Calculator for UOS

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     Calculator for UOS

--- a/mips64/linglong.yaml
+++ b/mips64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     Calculator for UOS

--- a/sw64/linglong.yaml
+++ b/sw64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     Calculator for UOS


### PR DESCRIPTION
As title.

Log: update version to 6.5.33

## Summary by Sourcery

Chores:
- Update version identifiers to 6.5.33.1 in linglong.yaml for the main package and all supported architectures.