### PR TITLE
chore: Bump version to 6.5.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-calculator (6.5.34) unstable; urgency=medium
+
+  * chore: Unify linglong.yaml
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 05 Mar 2026 19:18:34 +0800
+
 deepin-calculator (6.5.33) unstable; urgency=medium
 
   * fix: Fix build fail for invalid compiler flags

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.calculator
   name: deepin-calculator
-  version: 6.5.33.1
+  version: 6.5.34.1
   kind: app
   description: |
     Calculator for UOS


### PR DESCRIPTION
As title.

Log: Bump version to 6.5.34

## Summary by Sourcery

Build:
- Update package configuration to reference application version 6.5.34.