### PR TITLE
fix: resolve Qt6 assertion crashes in unit tests

### DIFF
--- a/3rdparty/core/functions.cpp
+++ b/3rdparty/core/functions.cpp
@@ -974,6 +974,11 @@ void FunctionRepo::createFunctions()
     FUNCTION_INSERT(ieee754_quad_encode);
 }
 
+Function::Function()
+    : m_error(Success)
+{
+}
+
 FunctionRepo *FunctionRepo::instance()
 {
     if (!s_FunctionRepoInstance) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,15 +181,16 @@ install(FILES ${CMAKE_CURRENT_LIST_DIR}/src/assets/images/deepin-calculator.svg
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/src/assets/deepin-calculator
                 DESTINATION ${CMAKE_INSTALL_DATADIR}/deepin-manual/manual-assets/application/)
 
-#if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "loongarch64")
-# 禁用测试
-# if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-# option (BUILD_TESTING "" ON)
-# if (BUILD_TESTING)
-# add_subdirectory(tests)  #tests为ut测试文件夹名
-# endif ()
-# endif ()
-#endif ()
+# 启用单元测试 (Debug 模式下)
+if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "loongarch64")
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    option (BUILD_TESTING "" ON)
+    if (BUILD_TESTING)
+      enable_testing()
+      add_subdirectory(tests)  # tests 为 ut 测试文件夹名
+    endif ()
+  endif ()
+endif ()
 
 #代码覆盖率开关
 if(CMAKE_COVERAGE_ARG STREQUAL "CMAKE_COVERAGE_ARG_ON")

--- a/src/views/simplelistdelegate.cpp
+++ b/src/views/simplelistdelegate.cpp
@@ -433,6 +433,11 @@ QSize SimpleListDelegate::sizeHint(const QStyleOptionViewItem &option,
 void SimpleListDelegate::cutApart(const QString text, QString &linkNum, QString &expStr)
 {
     QString exp = text;
+    if (exp.isEmpty()) {
+        linkNum = "";
+        expStr = "";
+        return;
+    }
     QStringList list;
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     list = exp.split(QRegExp("[＋－×÷/()]"), QString::SkipEmptyParts);
@@ -446,22 +451,29 @@ void SimpleListDelegate::cutApart(const QString text, QString &linkNum, QString 
     }
     if (exp.at(0) != QChar(QStringLiteral("－").at(0))) {
         int index = 0;
-        while (exp.at(index) == QChar('(')) {
+        while (index < exp.size() && exp.at(index) == QChar('(')) {
             ++index;
             linkNum.append("(");
-            if (exp.at(index) == QChar(QStringLiteral("－").at(0)))
+            if (index < exp.size() && exp.at(index) == QChar(QStringLiteral("－").at(0))) {
                 linkNum.append("－");
+            }
         }
         linkNum.append(list.at(0));
     } else {
         linkNum.append("－");
-        if (exp.at(1) == QChar('('))
+        if (exp.size() > 1 && exp.at(1) == QChar('('))
             linkNum.append("(");
         linkNum.append(list.at(0));
     }
-    if (linkNum.at(linkNum.size() - 1) == QChar('E'))
-        linkNum = linkNum + exp.at(exp.indexOf("E") + 1) + list.at(1);
-    expStr = text.right(text.length() - linkNum.length());
+    if (linkNum.at(linkNum.size() - 1) == QChar('E')) {
+        int eIdx = exp.indexOf("E");
+        if (eIdx >= 0 && eIdx + 1 < exp.size() && list.size() > 1)
+            linkNum = linkNum + exp.at(eIdx + 1) + list.at(1);
+    }
+    if (text.length() >= linkNum.length())
+        expStr = text.right(text.length() - linkNum.length());
+    else
+        expStr = "";
 }
 
 /**

--- a/src/views/simplelistmodel.cpp
+++ b/src/views/simplelistmodel.cpp
@@ -144,14 +144,25 @@ void SimpleListModel::updataList(const QString &text, const int index, bool sci)
         appendText(exp, sci); //科学模式上方历史记录区
     } else {
         if (sci) {
-            beginInsertRows(QModelIndex(), index, index);
-            m_expressionList.insert(index, exp);
+            // 删除元素后列表缩小，确保插入位置不越界
+            int insertIdx = qMin(index, m_expressionList.count());
+            beginInsertRows(QModelIndex(), insertIdx, insertIdx);
+            m_expressionList.insert(insertIdx, exp);
             endInsertRows();
         } else {
-            beginRemoveRows(QModelIndex(), index, index);
-            m_expressionList.removeAt(index);
-            m_expressionList.insert(index, exp);
-            endRemoveRows();
+            if (m_expressionList.isEmpty()) {
+                // 列表为空时无法替换，直接追加
+                beginInsertRows(QModelIndex(), 0, 0);
+                m_expressionList << exp;
+                endInsertRows();
+            } else {
+                // 替换已有元素，确保索引在有效范围内
+                int replaceIdx = qMin(index, m_expressionList.count() - 1);
+                beginRemoveRows(QModelIndex(), replaceIdx, replaceIdx);
+                m_expressionList.removeAt(replaceIdx);
+                m_expressionList.insert(replaceIdx, exp);
+                endRemoveRows();
+            }
         }
     }
 }
@@ -173,8 +184,10 @@ void SimpleListModel::updataList(Quantity ans, const QString &text, const int in
           .replace(EN_MIN, CN_MIN)
           .replace(EN_MUL, CN_MUL);
 
-    beginInsertRows(QModelIndex(), index, index);
-    m_expressionList.insert(index, exp);
+    // 删除元素后列表缩小，确保插入位置不越界
+    int insertIdx = qMin(index, m_expressionList.count());
+    beginInsertRows(QModelIndex(), insertIdx, insertIdx);
+    m_expressionList.insert(insertIdx, exp);
     endInsertRows();
     m_answerlist.insert(0, ans);
 }

--- a/src/widgets/expressionbar.cpp
+++ b/src/widgets/expressionbar.cpp
@@ -6,6 +6,7 @@
 #include "expressionbar.h"
 
 #include "../utils.h"
+#include "../globaldefine.h"
 #include "../../3rdparty/core/settings.h"
 
 #include <QApplication>
@@ -586,7 +587,9 @@ void ExpressionBar::enterPercentEvent()
     QString sRegNum = "[＋－×÷/(^!%E]";
     QRegularExpression rx;
     rx.setPattern(sRegNum);
-    QRegularExpressionMatch match = rx.match(exp.at(curpos - 1));
+    QRegularExpressionMatch match;
+    if (curpos > 0)
+        match = rx.match(exp.at(curpos - 1));
     if (curpos == 0 || match.hasMatch()) {
         m_inputEdit->insert("");
         diff = -1;
@@ -1339,7 +1342,7 @@ QString ExpressionBar::pointFaultTolerance(const QString &text)
     }
 
     for (int i = 0; i < reformatStr.size(); ++i) {
-        if (reformatStr.at(i) == QChar('＋') || reformatStr.at(i) == QChar('－') || reformatStr.at(i) == QChar('×') || reformatStr.at(i) == QChar('÷')) {
+        if (reformatStr.at(i) == CN_ADD.at(0) || reformatStr.at(i) == CN_MIN.at(0) || reformatStr.at(i) == CN_MUL.at(0) || reformatStr.at(i) == CN_DIV.at(0)) {
             if (i == 0)
                 continue;
             QString leftitem = reformatStr.left(i);
@@ -1593,8 +1596,10 @@ bool ExpressionBar::cancelLink(int index)
         if (m_hisLink[i].linkedItem == m_hisRevision) {
             QString exp = m_inputEdit->text();
             exp = exp.replace(",", "");
+            if (exp.isEmpty())
+                continue;
             QStringList list = exp.split(QRegularExpression("[＋－×÷()]"));
-            if (exp[0] == QChar(QStringLiteral("－").at(0)))
+            if (exp[0] == QChar(QStringLiteral("－").at(0)) && list.size() > 1)
                 list[0] = "－" + list[1];
             QString linkvalue = m_hisLink[i].linkageValue;
             linkvalue = linkvalue.replace(",", "");

--- a/src/widgets/proexpressionbar.cpp
+++ b/src/widgets/proexpressionbar.cpp
@@ -680,7 +680,9 @@ void ProExpressionBar::enterOppositeEvent()
     rx1.setPattern(sRegNum1);
     rx2.setPattern(sRegNum2);
     QRegularExpressionMatch match1 = rx1.match(exp.at(curPos - 1));
-    QRegularExpressionMatch match2 = rx2.match(exp.at(curPos - 2));
+    QRegularExpressionMatch match2;
+    if (curPos >= 2)
+        match2 = rx2.match(exp.at(curPos - 2));
     if (match1.hasMatch())
         return;
     else if (exp.at(curPos - 1) == QChar('0') && (curPos <= 1 || !match2.hasMatch())) {

--- a/src/widgets/sciexpressionbar.cpp
+++ b/src/widgets/sciexpressionbar.cpp
@@ -188,17 +188,24 @@ void SciExpressionBar::enterSymbolEvent(const QString &text)
 
             // 2020316修复添加符号后光标问题
             //添加符号后左侧数字不会多分隔符，只需考虑添加符号后输入框光标前的数字与添加前是否一致
-            if (exp.mid(0, curPos).remove(QRegularExpression("[＋－×÷/,.%()E]")) ==
-                    m_inputEdit->text().mid(0, curPos).remove(QRegularExpression("[＋－×÷/,.%()E]"))) {
+            QString newText = m_inputEdit->text();
+            int safeCurPos = qMin(curPos, qMin(exp.size(), newText.size()));
+            if (safeCurPos > 0 &&
+                    exp.mid(0, safeCurPos).remove(QRegularExpression("[＋－×÷/,.%()E]")) ==
+                    newText.mid(0, safeCurPos).remove(QRegularExpression("[＋－×÷/,.%()E]"))) {
                 QString sRegNum = "[＋－×÷/]";
                 QRegularExpression rx;
                 rx.setPattern(sRegNum);
-                QRegularExpressionMatch match = rx.match(m_inputEdit->text().at(curPos));
-                match.hasMatch()
-                ? m_inputEdit->setCursorPosition(curPos + 1)
-                : m_inputEdit->setCursorPosition(curPos);
+                if (safeCurPos < newText.size()) {
+                    QRegularExpressionMatch match = rx.match(newText.at(safeCurPos));
+                    match.hasMatch()
+                    ? m_inputEdit->setCursorPosition(safeCurPos + 1)
+                    : m_inputEdit->setCursorPosition(safeCurPos);
+                } else {
+                    m_inputEdit->setCursorPosition(safeCurPos);
+                }
             } else
-                m_inputEdit->setCursorPosition(curPos - 1);
+                m_inputEdit->setCursorPosition(qMax(0, safeCurPos - 1));
         }
     }
     m_isContinue = true;
@@ -323,13 +330,16 @@ void SciExpressionBar::enterBackspaceEvent()
         QString text = m_inputEdit->text();
         QString seloldtext = text;
         int removepos = 0; //被删除位置
-        QRegularExpressionMatch match1 = rx.match(m_inputEdit->text().at(selection.curpos - 1));
-        QRegularExpressionMatch match2 = rx.match(m_inputEdit->text().at(selection.curpos + selection.selected.size()));
+        QRegularExpressionMatch match1, match2;
+        if (selection.curpos > 0 && selection.curpos - 1 < text.size())
+            match1 = rx.match(text.at(selection.curpos - 1));
+        if (selection.curpos + selection.selected.size() < text.size())
+            match2 = rx.match(text.at(selection.curpos + selection.selected.size()));
 
         //光标不在开头且光标左侧是字母或者光标右侧是字母
         if ((selection.curpos > 0 &&
                 match1.hasMatch())
-                || (selection.curpos + selection.selected.size() < m_inputEdit->text().size() && match2.hasMatch())) {
+                || (selection.curpos + selection.selected.size() < text.size() && match2.hasMatch())) {
             int selleftfunlen = 0; //选中左侧一部分函数长度
             int funpos = -1;
             int rightfunpos = -1;
@@ -655,7 +665,9 @@ void SciExpressionBar::enterOperatorEvent(const QString &text)
     QString sRegNum = "[＋－×÷/(^]";
     QRegularExpression rx;
     rx.setPattern(sRegNum);
-    QRegularExpressionMatch match = rx.match(exp.at(curpos - 1));
+    QRegularExpressionMatch match;
+    if (curpos > 0)
+        match = rx.match(exp.at(curpos - 1));
     if (curpos == 0) {
         m_inputEdit->insert(zerotext);
         diff = 1;
@@ -682,7 +694,8 @@ void SciExpressionBar::enterOperatorEvent(const QString &text)
             m_inputEdit->setCursorPosition(curpos + length + diff);
         }
         //对于^2,^3类型的，在后面接数字的时候补乘号
-        if (isnumber(text.back()) && isnumber(m_inputEdit->text().at(m_inputEdit->cursorPosition()))) {
+        if (isnumber(text.back()) && m_inputEdit->cursorPosition() < m_inputEdit->text().size()
+                && isnumber(m_inputEdit->text().at(m_inputEdit->cursorPosition()))) {
             m_inputEdit->insert("×");
             m_inputEdit->setCursorPosition(m_inputEdit->cursorPosition() - 1);
         }
@@ -944,8 +957,10 @@ void SciExpressionBar::shear()
     QString seloldtext = text;
 
     // 光标不在开头且光标左侧是字母或者光标右侧是字母
-    QChar leftChar = m_inputEdit->text().at(selection.curpos - 1);
-    QChar rightChar = m_inputEdit->text().at(selection.curpos + selection.selected.size());
+    QChar leftChar = (selection.curpos > 0 && selection.curpos - 1 < text.size())
+                     ? text.at(selection.curpos - 1) : QChar();
+    QChar rightChar = (selection.curpos + selection.selected.size() < text.size())
+                      ? text.at(selection.curpos + selection.selected.size()) : QChar();
 
     QRegularExpressionMatch leftMatch = rx.match(QString(leftChar));
     QRegularExpressionMatch rightMatch = rx.match(QString(rightChar));
@@ -1038,8 +1053,10 @@ void SciExpressionBar::deleteText()
     QString seloldtext = text;
 
     //光标不在开头且光标左侧是字母或者光标右侧是字母
-    QChar leftChar = m_inputEdit->text().at(selection.curpos - 1);
-    QChar rightChar = m_inputEdit->text().at(selection.curpos + selection.selected.size());
+    QChar leftChar = (selection.curpos > 0 && selection.curpos - 1 < text.size())
+                     ? text.at(selection.curpos - 1) : QChar();
+    QChar rightChar = (selection.curpos + selection.selected.size() < text.size())
+                      ? text.at(selection.curpos + selection.selected.size()) : QChar();
 
     // 将 QChar 转换为 QString 进行匹配
     QRegularExpressionMatch leftMatch = rx.match(QString(leftChar));
@@ -1216,9 +1233,12 @@ bool SciExpressionBar::judgeinput()
     SSelection selection = m_inputEdit->getSelection();
 
     if (selection.selected != "") {
+        QString text = m_inputEdit->text();
         // 光标不在开头且光标左侧是字母或者光标右侧是字母
-        QChar leftChar = m_inputEdit->text().at(selection.curpos - 1);
-        QChar rightChar = m_inputEdit->text().at(selection.curpos + selection.selected.size());
+        QChar leftChar = (selection.curpos > 0 && selection.curpos - 1 < text.size())
+                         ? text.at(selection.curpos - 1) : QChar();
+        QChar rightChar = (selection.curpos + selection.selected.size() < text.size())
+                          ? text.at(selection.curpos + selection.selected.size()) : QChar();
 
         // 使用 match() 和 hasMatch() 替代 exactMatch
         QRegularExpressionMatch leftMatch = rx.match(QString(leftChar));
@@ -1468,9 +1488,9 @@ void SciExpressionBar::expressionCheck()
         }
     }
     for (int i = 0; i < expNorm.size(); ++i) {
-        while (expNorm[i].isNumber()) {
+        while (i < expNorm.size() && expNorm[i].isNumber()) {
             // fix for delete 0 behind "."
-            if (expNorm[i] == QChar('0') && expNorm[i + 1] != QChar('.') && (i == 0 || expNorm[i - 1] != QChar('.')) &&
+            if (expNorm[i] == QChar('0') && i + 1 < expNorm.size() && expNorm[i + 1] != QChar('.') && (i == 0 || expNorm[i - 1] != QChar('.')) &&
                     (i == 0 || !expNorm[i - 1].isNumber()) && (expNorm.size() == 1 || expNorm[i + 1].isNumber())) {
                 expNorm.remove(i, 1);
                 --i;
@@ -1479,7 +1499,7 @@ void SciExpressionBar::expressionCheck()
             }
             ++i;
         }
-        if (expNorm[i] == QChar('.') && (i == 0 || !expNorm[i - 1].isNumber())) {
+        if (i < expNorm.size() && expNorm[i] == QChar('.') && (i == 0 || !expNorm[i - 1].isNumber())) {
             expNorm.insert(i, "0");
             ++i;
             if (i < cur)
@@ -1499,7 +1519,11 @@ void SciExpressionBar::expressionCheck()
         result.replace(decimalPlaceholder, decSym);
 
     m_inputEdit->setText(result);
-    m_inputEdit->setCursorPosition(cur + separator);
+    int finalPos = qMax(0, cur + separator);
+    if (finalPos <= result.length())
+        m_inputEdit->setCursorPosition(finalPos);
+    else
+        m_inputEdit->setCursorPosition(result.length());
 }
 
 bool SciExpressionBar::isnumber(QChar a)
@@ -1726,6 +1750,8 @@ bool SciExpressionBar::isOperator(const QString &text)
 
 void SciExpressionBar::moveLeft()
 {
+    if (m_inputEdit->text().isEmpty())
+        return;
     QString sRegNum = "[A-Za-z]";
     QRegularExpression rx;
     rx.setPattern(sRegNum);
@@ -1752,9 +1778,13 @@ void SciExpressionBar::moveLeft()
 
 void SciExpressionBar::moveRight()
 {
+    if (m_inputEdit->text().isEmpty())
+        return;
     QString sRegNum = "[A-Za-z]";
     QRegularExpression rx;
     rx.setPattern(sRegNum);
+    if (m_inputEdit->cursorPosition() >= m_inputEdit->text().size())
+        return;
     QRegularExpressionMatch match = rx.match(m_inputEdit->text().at(m_inputEdit->cursorPosition()));
     if (!cursorPosAtEnd() && match.hasMatch()) {
         int funpos = -1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,27 +2,29 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#源程序cmakelists再添加上ut相关环境搭建
+# 单元测试 CMakeLists.txt - Qt6 兼容版本
 
-cmake_minimum_required(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.16.0)
 
 if (NOT DEFINED VERSION)
     set(VERSION 1.2.2)
 endif ()
 
+project(deepin-calculator-test)
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
 ADD_COMPILE_OPTIONS(-fno-access-control)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wl,--as-needed -fPIE")
-set(QT_MINIMUM_VERSION "5.7.1")
-set(CMAKE_EXE_LINKER_FLAGS "-pie")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 
-#add_definitions(-DQT_NO_DEBUG_OUTPUT)
+# Qt6 minimum version
+set(QT_MINIMUM_VERSION "6.0.0")
 
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mieee")
@@ -33,55 +35,43 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ftree-vectorize -march=loongson3a -mhard-float -mno-micromips -mno-mips16 -flax-vector-conversions -mloongson-ext2 -mloongson-mmi -Wl,--as-needed")
 endif()
 
-if (NOT (${CMAKE_BUILD_TYPE} MATCHES "Debug"))
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-
-    execute_process(COMMAND bash "${CMAKE_CURRENT_LIST_DIR}/../translate_generation.sh"
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../)
-endif ()
-
 configure_file(${CMAKE_CURRENT_LIST_DIR}/../src/environments.h.in environments.h @ONLY)
 
-# Find the library
+# Find the Qt6 library
 find_package(PkgConfig REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Gui REQUIRED)
-find_package(Qt5DBus REQUIRED)
-find_package(Qt5Xml REQUIRED)
-find_package(Qt5Svg REQUIRED)
-find_package(Qt5Test REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Core Gui DBus Xml Svg Test)
 
-find_package(DtkWidget REQUIRED dtkwidget)
-find_package(DtkGui REQUIRED dtkgui)
-find_package(DtkCore REQUIRED dtkcore)
+# Find Dtk6 via CMake (not pkg-config)
+find_package(Dtk6 REQUIRED COMPONENTS Widget Gui Core)
 
-include_directories(${DtkWidget_INCLUDE_DIRS})
-include_directories(${DtkGui_INCLUDE_DIRS})
-include_directories(${DtkCore_INCLUDE_DIRS})
+include_directories(${Dtk6Widget_INCLUDE_DIRS})
+include_directories(${Dtk6Gui_INCLUDE_DIRS})
+include_directories(${Dtk6Core_INCLUDE_DIRS})
 
+# gtest/gmock
 pkg_check_modules(GTEST REQUIRED
     gtest
     gmock
-    )
+)
 
 set (EXE_NAME deepin-calculator)
 
+# Qt6 link libraries
 set(LINK_LIBS
-    Qt5::Core
-    Qt5::DBus
-    Qt5::Widgets
-    Qt5::Xml
-    Qt5::Svg
-    Qt5::Test
+    Qt6::Core
+    Qt6::DBus
+    Qt6::Widgets
+    Qt6::Xml
+    Qt6::Svg
+    Qt6::Test
 
-    ${DtkWidget_LIBRARIES}
-    ${DtkCore_LIBRARIES}
-    ${DtkGUI_LIBRARIES}
+    Dtk6::Widget
+    Dtk6::Gui
+    Dtk6::Core
     ${DFrameworkDBus_LIBRARIES}
 )
 
-#CMAKE_CURRENT_LIST_DIR缓存文件的目录，头文件找不到问题解决方案1,文件中未使用该头文件变量　2,CMAKE_CURRENT_LIST_DIR改为CMAKE_SOURCE_DIR
+# Head file search path
 SET(HEAD ${CMAKE_CURRENT_LIST_DIR}/../src
          ${CMAKE_CURRENT_LIST_DIR}/../src/bak
          ${CMAKE_CURRENT_LIST_DIR}/../src/control
@@ -89,8 +79,10 @@ SET(HEAD ${CMAKE_CURRENT_LIST_DIR}/../src
          ${CMAKE_CURRENT_LIST_DIR}/../3rdparty/math
          ${CMAKE_CURRENT_LIST_DIR}/../src/views
          ${CMAKE_CURRENT_LIST_DIR}/../src/widgets
+         ${CMAKE_CURRENT_LIST_DIR}/src  # For qt6_compat.h
          )
 
+# Source files from main project
 file(GLOB_RECURSE CAL_H ${CMAKE_CURRENT_LIST_DIR}/../src/*.h)
 file(GLOB_RECURSE CAL_C ${CMAKE_CURRENT_LIST_DIR}/../src/*.c)
 file(GLOB_RECURSE CAL_CPP ${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp)
@@ -99,10 +91,10 @@ file(GLOB_RECURSE CAL_3rdC ${CMAKE_CURRENT_LIST_DIR}/../3rdparty/*.c)
 file(GLOB_RECURSE CAL_3rdCPP ${CMAKE_CURRENT_LIST_DIR}/../3rdparty/*.cpp)
 list(REMOVE_ITEM CAL_CPP "${CMAKE_CURRENT_LIST_DIR}/../src/main.cpp")
 
+# Test source files
 file(GLOB_RECURSE CAL_TEST ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
 file(GLOB_RECURSE CAL_TESTH ${CMAKE_CURRENT_LIST_DIR}/src/*.h)
 
-#find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
 set (DC_QRC_FILES
@@ -110,27 +102,26 @@ set (DC_QRC_FILES
 )
 
 set(PROJECT_NAME_TEST
-    ${PROJECT_NAME}-test)
+    ${EXE_NAME}-test)
 
-# 生成测试可执行程序
+# Generate test executable
 add_executable(${PROJECT_NAME_TEST} ${CAL_H} ${CAL_C} ${CAL_CPP} ${CAL_3rdH} ${CAL_3rdC} ${CAL_3rdCPP} ${CAL_TEST} ${CAL_TESTH})
 
-# 生成测试可执行程序的依赖库
+# Link gtest/gmock libraries
 target_link_libraries(${PROJECT_NAME_TEST} ${GTEST_LIBRARYS} ${GTEST_MAIN_LIBRARYS} gmock gmock_main gtest gtest_main pthread)
 
-target_include_directories(${PROJECT_NAME_TEST} PUBLIC ${Qt5Widgets_LIBRARIES}
-                                              ${Qt5DBus_LIBRARIES}
-                                              ${Qt5TestLib_LIBRARIES}
+target_include_directories(${PROJECT_NAME_TEST} PUBLIC ${Qt6Widgets_INCLUDE_DIRS}
+                                              ${Qt6DBus_INCLUDE_DIRS}
+                                              ${Qt6Test_INCLUDE_DIRS}
                                               ${PROJECT_BINARY_DIR}
-                                              ${DtkWidget_INCLUDE_DIRS}
-                                              ${DtkCore_LIBRARIES}
-                                              ${DtkGUI_INCLUDE_DIRS}
+                                              ${Dtk6Widget_INCLUDE_DIRS}
+                                              ${Dtk6Core_INCLUDE_DIRS}
+                                              ${Dtk6Gui_INCLUDE_DIRS}
                                               ${DFrameworkDBus_INCLUDE_DIRS}
                                               ${GTEST_INCLUDE_DIRS}
                                               ${HEAD})
 target_link_libraries (${PROJECT_NAME_TEST} ${LINK_LIBS})
 
-#set(CMAKE_INSTALL_PREFIX /usr)
 if(DEFINED ENV{PREFIX})
     set(CMAKE_INSTALL_PREFIX $ENV{PREFIX})
 else()
@@ -146,43 +137,21 @@ install(FILES ${CMAKE_CURRENT_LIST_DIR}/../src/assets/images/deepin-calculator.s
             DESTINATION share/icons/hicolor/scalable/apps/)
 
 
-#------------------------------ 创建'make test'指令---------------------------------------
-add_custom_target(test
-#    COMMAND mkdir -p tests/coverageResult
-#    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
+#------------------------------ 创建单元测试执行目标---------------------------------------
+# 注意: 由于 enable_testing() 已启用, 'test' 目标由 CTest 保留
+# 使用 'ut_run' 作为自定义目标名称
 
-add_custom_command(TARGET test
-    COMMAND echo " =================== CREAT LCOV REPROT BEGIN ==================== "
+add_custom_target(ut_run)
 
-    #1.清理原先的gcov信息
-#    COMMAND lcov --directory ./tests/CMakeFiles/${PROJECT_NAME_TEST}.dir --zerocounters
-#    COMMAND lcov --directory ./tests/CMakeFiles/${PROJECT_NAME}.dir --zerocounters
+add_custom_command(TARGET ut_run
+    COMMAND echo " =================== RUN UNIT TESTS ==================== "
     COMMAND ${CMAKE_BINARY_DIR}/tests/${PROJECT_NAME_TEST}
-
-
-    #2.收集gcov信息到.info文件中
-#    COMMAND lcov --directory . --capture --output-file ./tests/coverageResult/${PROJECT_NAME}_Coverage.info
-
-    #3.过滤一些我们不感兴趣的文件的覆盖率信息
-#    COMMAND echo " =================== do filter begin ==================== "
-#    COMMAND lcov --remove ./tests/coverageResult/${PROJECT_NAME}_Coverage.info
-#    '*/${PROJECT_NAME_TEST}_autogen/*' '*/${PROJECT_NAME}_autogen/*' '*/tests/*' '*/googletest/*' '*/usr/include/*' '*/src/bak/*' '*/src/core/*' '*/src/math/*'
-#    -o ./tests/coverageResult/${PROJECT_NAME}_Coverage.info
-#    COMMAND echo " =================== do filter end ==================== "
-
-    #3.将.info信息生成报告到reprot文件夹中
-#    COMMAND genhtml -o ./tests/coverageResult/report ./coverageResult/${PROJECT_NAME}_Coverage.info
-
-    COMMAND echo " =================== CREAT LCOV REPROT END ==================== "
-
-#    COMMAND echo " Coverage files have been output to ${CMAKE_BINARY_DIR}/coverageResult/report "
-
-#    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMAND echo " =================== TESTS COMPLETED ==================== "
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 
-#'make test'命令依赖与我们的测试程序
-add_dependencies(test ${PROJECT_NAME_TEST})
+#'make ut_run'命令依赖与我们的测试程序
+add_dependencies(ut_run ${PROJECT_NAME_TEST})
 
 # 设置添加gocv相关信息的输出
 set(CMAKE_CXX_FLAGS "-g -fprofile-arcs -ftest-coverage")
@@ -196,4 +165,3 @@ if(CMAKE_SAFETYTEST STREQUAL "CMAKE_SAFETYTEST_ARG_ON")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fsanitize=undefined,address -O2")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=undefined,address -O2")
 endif()
-

--- a/tests/cmake-lcov-test.sh
+++ b/tests/cmake-lcov-test.sh
@@ -1,21 +1,23 @@
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-utdir=build-ut
-rm -r $utdir
-rm -r ../$utdir
-mkdir ../$utdir
-cd ../$utdir
+utdir=build-test
+rm -r $utdir 2>/dev/null || true
+rm -r ../$utdir 2>/dev/null || true
+mkdir ../$utdir 2>/dev/null || true
+cd ../$utdir || exit 1
 
 cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j16
+make -j8
+
+mkdir -p report
 
 ./tests/deepin-calculator-test --gtest_output=xml:./report/report.xml
 
 workdir=$(cd ../$(dirname $0)/$utdir; pwd)
-
-mkdir -p report
 
 lcov -d $workdir -c -o ./report/coverage.info
 
@@ -24,5 +26,7 @@ lcov --extract ./report/coverage.info '*/src/*' -o ./report/coverage.info
 lcov --remove ./report/coverage.info '*/tests/*' -o ./report/coverage.info
 
 genhtml -o ./report ./report/coverage.info
+
+echo "测试完成！报告已生成到: ./report"
 
 exit 0

--- a/tests/src/control/ut_bitbutton.cpp
+++ b/tests/src/control/ut_bitbutton.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_bitbutton.h"
 #include "../../src/control/bitbutton.h"
 
@@ -71,7 +72,7 @@ TEST_F(Ut_BitButton, mouseReleaseEvent)
 TEST_F(Ut_BitButton, enterEvent)
 {
     BitButton *m_bitbutton = new BitButton;
-    QEvent *q = new QEvent(QEvent::Type::Enter);
+    QEnterEvent *q = createEnterEvent();
 
     m_bitbutton->enterEvent(q);
     delete q;
@@ -82,7 +83,7 @@ TEST_F(Ut_BitButton, enterEvent)
 TEST_F(Ut_BitButton, leaveEvent)
 {
     BitButton *m_bitbutton = new BitButton;
-    QEvent *q = new QEvent(QEvent::Type::Leave);
+    QEvent *q = createLeaveEvent();
 
     m_bitbutton->leaveEvent(q);
     delete q;
@@ -129,13 +130,13 @@ TEST_F(Ut_BitButton, paintEvent)
 {
     BitButton *m_bitbutton = new BitButton;
     QPaintEvent *event = new QPaintEvent(m_bitbutton->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::UnknownType);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::UnknownType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_bitbutton->m_isHover = true;
     m_bitbutton->m_isPress = true;
     m_bitbutton->paintEvent(event);
     m_bitbutton->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_bitbutton->paintEvent(event);
     delete event;
     //paintevent,无ASSERT

--- a/tests/src/control/ut_equalbutton.cpp
+++ b/tests/src/control/ut_equalbutton.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_equalbutton.h"
 #include "../../src/control/equalbutton.h"
 
@@ -50,7 +51,7 @@ TEST_F(Ut_EqualButton, mouseReleaseEvent)
 TEST_F(Ut_EqualButton, enterEvent)
 {
     EqualButton *m_equalButton = new EqualButton;
-    QEvent *e = new QEvent(QEvent::Type::Enter);
+    QEnterEvent *e = createEnterEvent();
     m_equalButton->enterEvent(e);
     delete e;
     EXPECT_TRUE(m_equalButton->m_isHover);
@@ -60,7 +61,7 @@ TEST_F(Ut_EqualButton, enterEvent)
 TEST_F(Ut_EqualButton, leaveEvent)
 {
     EqualButton *m_equalButton = new EqualButton;
-    QEvent *e = new QEvent(QEvent::Type::Leave);
+    QEvent *e = createLeaveEvent();
     m_equalButton->leaveEvent(e);
     delete e;
     EXPECT_FALSE(m_equalButton->m_isHover);
@@ -76,13 +77,13 @@ TEST_F(Ut_EqualButton, paintEvent)
 {
     EqualButton *m_equalButton = new EqualButton();
     QPaintEvent *event = new QPaintEvent(m_equalButton->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_equalButton->setEnabled(true);
     m_equalButton->m_isHover = true;
     m_equalButton->m_isPress = false;
     m_equalButton->paintEvent(event);
     m_equalButton->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_equalButton->paintEvent(event);
     m_equalButton->m_isHover = false;
     m_equalButton->m_isPress = true;

--- a/tests/src/control/ut_iconbutton.cpp
+++ b/tests/src/control/ut_iconbutton.cpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "ut_iconbutton.h"
 #include "../../src/control/iconbutton.h"
+#include "qt6_compat.h"
 
 Ut_IconButton::Ut_IconButton()
 {
@@ -126,7 +127,7 @@ TEST_F(Ut_IconButton, enterEvent)
 {
     IconButton *m_iconButton = new IconButton;
     m_iconButton->setIconUrl("a", "b", "c", 1);
-    QEvent *e = new QEvent(QEvent::Type::Enter);
+    QEnterEvent *e = createEnterEvent();
     m_iconButton->enterEvent(e);
     EXPECT_TRUE(m_iconButton->m_isHover);
     EXPECT_EQ(m_iconButton->m_buttonStatus, 1);
@@ -139,7 +140,7 @@ TEST_F(Ut_IconButton, leaveEvent)
 {
     IconButton *m_iconButton = new IconButton;
     m_iconButton->setIconUrl("a", "b", "c", 1);
-    QEvent *e = new QEvent(QEvent::Type::Leave);
+    QEvent *e = createLeaveEvent();
     m_iconButton->leaveEvent(e);
     EXPECT_FALSE(m_iconButton->m_isHover);
     EXPECT_EQ(m_iconButton->m_buttonStatus, 0);
@@ -158,14 +159,14 @@ TEST_F(Ut_IconButton, paintEvent)
 {
     IconButton *m_iconButton = new IconButton;
     QPaintEvent *event = new QPaintEvent(m_iconButton->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::UnknownType);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::UnknownType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_iconButton->m_isHover = true;
     m_iconButton->m_isPress = false;
     m_iconButton->m_isEmptyBtn = false;
     m_iconButton->paintEvent(event);
     m_iconButton->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_iconButton->m_isHover = false;
     m_iconButton->m_isPress = true;
     m_iconButton->m_isEmptyBtn = false;
@@ -210,7 +211,7 @@ TEST_F(Ut_IconButton, paintEvent)
     m_iconButton->m_isPress = false;
     m_iconButton->paintEvent(event);
     m_iconButton->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_iconButton->m_isHover = false;
     m_iconButton->m_isPress = true;
     m_iconButton->m_isEmptyBtn = false;

--- a/tests/src/control/ut_memorybutton.cpp
+++ b/tests/src/control/ut_memorybutton.cpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "ut_memorybutton.h"
 #include "../../src/control/memorybutton.h"
+#include "qt6_compat.h"
 
 Ut_MemoryButton::Ut_MemoryButton()
 {
@@ -132,7 +133,7 @@ TEST_F(Ut_MemoryButton, mouseReleaseEvent)
 TEST_F(Ut_MemoryButton, enterEvent)
 {
     MemoryButton *m_memorybutton = new MemoryButton;
-    QEvent *q = new QEvent(QEvent::Type::Enter);
+    QEnterEvent *q = createEnterEvent();
     m_memorybutton->enterEvent(q);
     EXPECT_TRUE(m_memorybutton->m_isHover);
     EXPECT_EQ(m_memorybutton->m_font.pixelSize(), 17);
@@ -143,7 +144,7 @@ TEST_F(Ut_MemoryButton, enterEvent)
 TEST_F(Ut_MemoryButton, leaveEvent)
 {
     MemoryButton *m_memorybutton = new MemoryButton;
-    QEvent *q = new QEvent(QEvent::Type::Leave);
+    QEvent *q = createLeaveEvent();
     m_memorybutton->leaveEvent(q);
     EXPECT_FALSE(m_memorybutton->m_isHover);
     EXPECT_EQ(m_memorybutton->m_font.pixelSize(), 16);
@@ -170,14 +171,14 @@ TEST_F(Ut_MemoryButton, paintEvent)
 {
     MemoryButton *m_memorybutton = new MemoryButton;
     QPaintEvent *event = new QPaintEvent(m_memorybutton->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_memorybutton->setText("MH˅");
     m_memorybutton->setEnabled(true);
     m_memorybutton->m_isHover = true;
     m_memorybutton->m_isPress = false;
     m_memorybutton->paintEvent(event);
     m_memorybutton->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_memorybutton->setEnabled(false);
     m_memorybutton->m_isHover = false;
     m_memorybutton->m_isPress = false;
@@ -210,14 +211,14 @@ TEST_F(Ut_MemoryButton, paintEvent2)
 {
     MemoryButton *m_memorybutton = new MemoryButton;
     QPaintEvent *event = new QPaintEvent(m_memorybutton->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_memorybutton->setText("MH˄");
     m_memorybutton->setEnabled(true);
     m_memorybutton->m_isHover = true;
     m_memorybutton->m_isPress = false;
     m_memorybutton->paintEvent(event);
     m_memorybutton->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_memorybutton->setEnabled(false);
     m_memorybutton->m_isHover = false;
     m_memorybutton->m_isPress = false;
@@ -250,13 +251,13 @@ TEST_F(Ut_MemoryButton, paintEvent3)
 {
     MemoryButton *m_memorybutton = new MemoryButton(QString("M+"), true);
     QPaintEvent *event = new QPaintEvent(m_memorybutton->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_memorybutton->setEnabled(true);
     m_memorybutton->m_isHover = true;
     m_memorybutton->m_isPress = false;
     m_memorybutton->paintEvent(event);
     m_memorybutton->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_memorybutton->setEnabled(false);
     m_memorybutton->m_isHover = false;
     m_memorybutton->m_isPress = false;

--- a/tests/src/control/ut_textbutton.cpp
+++ b/tests/src/control/ut_textbutton.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_textbutton.h"
 #include "../../src/control/textbutton.h"
 
@@ -72,7 +73,7 @@ TEST_F(Ut_TextButton, mouseReleaseEvent)
 TEST_F(Ut_TextButton, enterEvent)
 {
     TextButton *m_textbutton = new TextButton;
-    QEvent *e = new QEvent(QEvent::Type::Enter);
+    QEnterEvent *e = createEnterEvent();
     m_textbutton->setText("Rand");
     m_textbutton->enterEvent(e);
     EXPECT_EQ(m_textbutton->m_font.pixelSize(), 17);
@@ -113,7 +114,7 @@ TEST_F(Ut_TextButton, enterEvent)
 TEST_F(Ut_TextButton, leaveEvent)
 {
     TextButton *m_textbutton = new TextButton;
-    QEvent *e = new QEvent(QEvent::Type::Leave);
+    QEvent *e = createLeaveEvent();
     m_textbutton->setText("Rand");
     m_textbutton->leaveEvent(e);
     EXPECT_EQ(m_textbutton->m_font.pixelSize(), 15);
@@ -160,12 +161,12 @@ TEST_F(Ut_TextButton, paintEvent)
 {
     TextButton *m_textbutton = new TextButton("1");
     QPaintEvent *event = new QPaintEvent(m_textbutton->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_textbutton->m_isHover = true;
     m_textbutton->m_isPress = false;
     m_textbutton->paintEvent(event);
     m_textbutton->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_textbutton->m_isHover = false;
     m_textbutton->m_isPress = true;
     m_textbutton->paintEvent(event);

--- a/tests/src/qt6_compat.h
+++ b/tests/src/qt6_compat.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef QT6_COMPAT_H
+#define QT6_COMPAT_H
+
+// Qt6 compatibility utilities for unit tests
+
+#include <QtGlobal>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+
+#include <QEnterEvent>
+#include <QEvent>
+#include <QPointF>
+
+/**
+ * @brief Create a QEnterEvent compatible with Qt6
+ *
+ * In Qt5, enter events used QEvent::Type::Enter with QWidget::enterEvent(QEvent*).
+ * In Qt6, enter events use QEnterEvent with QWidget::enterEvent(QEnterEvent*).
+ */
+inline QEnterEvent *createEnterEvent(const QPointF &localPos = QPointF(),
+                                     const QPointF &globalPos = QPointF())
+{
+    return new QEnterEvent(localPos, localPos, globalPos);
+}
+
+/**
+ * @brief Create a QEvent for Leave type (same in Qt5 and Qt6)
+ */
+inline QEvent *createLeaveEvent()
+{
+    return new QEvent(QEvent::Type::Leave);
+}
+
+/**
+ * @brief Compatibility macro for Dtk6 setThemeType
+ *
+ * In Dtk6, setThemeType() is removed. The theme is controlled by system settings.
+ * This macro provides a no-op to make tests compile with Dtk6.
+ */
+#define DTK_SET_THEME_TYPE(type) ((void)0)
+
+#else
+
+// Qt5 compat - these are the original patterns
+#include <QEvent>
+
+inline QEvent *createEnterEvent()
+{
+    return new QEvent(QEvent::Type::Enter);
+}
+
+inline QEvent *createLeaveEvent()
+{
+    return new QEvent(QEvent::Type::Leave);
+}
+
+// In Qt5/Dtk5, setThemeType is available
+#include <DGuiApplicationHelper>
+#define DTK_SET_THEME_TYPE(type) DGuiApplicationHelper::instance()->setThemeType(type)
+
+#endif
+
+#endif // QT6_COMPAT_H

--- a/tests/src/ut_mainwindow.cpp
+++ b/tests/src/ut_mainwindow.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_mainwindow.h"
 
 #include "../../src/mainwindow.h"
@@ -17,11 +18,11 @@ TestCala::TestCala()
 TEST_F(TestCala, initTheme)
 {
     MainWindow *m_mainwindow = new MainWindow;
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::UnknownType);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::UnknownType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_mainwindow->initTheme();
     EXPECT_EQ(m_mainwindow->titlebar()->palette().color(DPalette::Light), QColor(240, 240, 240));
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_mainwindow->initTheme();
     QColor color(0, 0, 0);
     color.setAlphaF(0.1);

--- a/tests/src/ut_memorypublic.cpp
+++ b/tests/src/ut_memorypublic.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_memorypublic.h"
 
 #include "../../src/memorypublic.h"
@@ -86,10 +87,10 @@ TEST_F(Ut_MemoryPublic, setThemeType)
     MemoryPublic *m_memoryPublic = MemoryPublic::instance();
     MemoryWidget *memorywidget = m_memoryPublic->getwidget(MemoryPublic::memorymode::scientificright);
     m_memoryPublic->m_list.clear();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_memoryPublic->setThemeType(0);
     EXPECT_EQ(memorywidget->m_clearbutton->m_currentUrl, ":/assets/images/light/empty_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_memoryPublic->setThemeType(0);
     EXPECT_EQ(memorywidget->m_clearbutton->m_currentUrl, ":/assets/images/dark/empty_normal.svg");
 }

--- a/tests/src/views/ut_memoryitemdelegate.cpp
+++ b/tests/src/views/ut_memoryitemdelegate.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_memoryitemdelegate.h"
 
 #include "../../src/views/memorylistwidget.h"
@@ -53,9 +54,9 @@ TEST_F(Ut_MemoryItemDelegate, paint)
     stub.set(ADDR(MemoryListWidget, hasFocus), stub_focus_memdelegateF);
 //    Stub stub1;
 //    stub1.set(ADDR(MemoryListWidget, rect), stub_rect_memdelegate);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_memoryItemDelegate->paint(painter, option, index);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_memoryItemDelegate->paint(painter, option, index);
     delete painter;
     //paint函数，无assert

--- a/tests/src/views/ut_memoryitemdelegate.h
+++ b/tests/src/views/ut_memoryitemdelegate.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
 #include <QTest>
-#include <DApplicationHelper>
+#include <DGuiApplicationHelper>
 #include"../stub.h"
 #include "../../src/views/memoryitemdelegate.h"
 

--- a/tests/src/views/ut_memoryitemwidget.cpp
+++ b/tests/src/views/ut_memoryitemwidget.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_memoryitemwidget.h"
 #include "../../src/views/memoryitemwidget.h"
 #include "../../src/dsettings.h"
@@ -27,7 +28,7 @@ TEST_F(Ut_MemoryItemWidget, connects)
 TEST_F(Ut_MemoryItemWidget, enterEvent)
 {
     MemoryItemWidget *m_memoryItemWidget = new MemoryItemWidget;
-    QEvent *e = new QEvent(QEvent::Type::MouseMove);
+    QEnterEvent *e = createEnterEvent();
     m_memoryItemWidget->enterEvent(e);
     EXPECT_TRUE(m_memoryItemWidget->m_ishover);
     EXPECT_FALSE(m_memoryItemWidget->m_btnplus->isHidden());
@@ -52,7 +53,7 @@ TEST_F(Ut_MemoryItemWidget, leaveEvent)
 
 TEST_F(Ut_MemoryItemWidget, mousePressEvent)
 {
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     MemoryItemWidget *m_memoryItemWidget = new MemoryItemWidget;
     QMouseEvent *m = new QMouseEvent(QMouseEvent::Type::MouseButtonPress,
                                      m_memoryItemWidget->pos(), Qt::MouseButton::RightButton,
@@ -70,7 +71,7 @@ TEST_F(Ut_MemoryItemWidget, mousePressEvent)
 
 TEST_F(Ut_MemoryItemWidget, mouseReleaseEvent)
 {
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     MemoryItemWidget *m_memoryItemWidget = new MemoryItemWidget;
     QMouseEvent *m = new QMouseEvent(QMouseEvent::Type::MouseButtonRelease,
                                      m_memoryItemWidget->pos(), Qt::MouseButton::LeftButton,
@@ -126,13 +127,13 @@ TEST_F(Ut_MemoryItemWidget, paintEvent)
 {
     MemoryItemWidget *m_memoryItemWidget = new MemoryItemWidget;
     QPaintEvent *event = new QPaintEvent(m_memoryItemWidget->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::UnknownType);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::UnknownType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_memoryItemWidget->m_ishover = true;
     m_memoryItemWidget->m_ispress = true;
     m_memoryItemWidget->paintEvent(event);
     m_memoryItemWidget->update();
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_memoryItemWidget->paintEvent(event);
     delete event;
     //paintevent无assert

--- a/tests/src/views/ut_programmerarrowdelegate.cpp
+++ b/tests/src/views/ut_programmerarrowdelegate.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_programmerarrowdelegate.h"
 
 #include "../../src/views/programmeritemwidget.h"
@@ -54,9 +55,9 @@ TEST_F(Ut_ProgrammerArrowDelegate, paint)
     stub.set(ADDR(MemoryListWidget, hasFocus), stub_focus_proarrowdelegateF);
 //    Stub stub1;
 //    stub1.set(ADDR(MemoryListWidget, rect), stub_rect_memdelegate);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_memoryItemDelegate->paint(painter, option, index);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_memoryItemDelegate->paint(painter, option, index);
     delete painter;
     //paint函数，无assert

--- a/tests/src/views/ut_programmerarrowdelegate.h
+++ b/tests/src/views/ut_programmerarrowdelegate.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
 #include <QTest>
-#include <DApplicationHelper>
+#include <DGuiApplicationHelper>
 #include"../stub.h"
 #include "../../src/views/programmerarrowdelegate.h"
 

--- a/tests/src/views/ut_programmeritemwidget.cpp
+++ b/tests/src/views/ut_programmeritemwidget.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "qt6_compat.h"
 #include "ut_programmeritemwidget.h"
 #include "../../src/views/programmeritemwidget.h"
 #include "../../src/dsettings.h"
@@ -16,7 +17,7 @@ Ut_ProgrammerItemWidget::Ut_ProgrammerItemWidget()
 TEST_F(Ut_ProgrammerItemWidget, enterEvent)
 {
     ProgrammerItemWidget *m_programmerItemWidget = new ProgrammerItemWidget("WORD");
-    QEvent *e = new QEvent(QEvent::Type::MouseMove);
+    QEnterEvent *e = createEnterEvent();
     m_programmerItemWidget->enterEvent(e);
     EXPECT_TRUE(m_programmerItemWidget->m_ishover);
     delete e;
@@ -26,7 +27,7 @@ TEST_F(Ut_ProgrammerItemWidget, enterEvent)
 TEST_F(Ut_ProgrammerItemWidget, leaveEvent)
 {
     ProgrammerItemWidget *m_programmerItemWidget = new ProgrammerItemWidget("WORD");
-    QEvent *e = new QEvent(QEvent::Type::MouseMove);
+    QEvent *e = createLeaveEvent();
     m_programmerItemWidget->leaveEvent(e);
     EXPECT_FALSE(m_programmerItemWidget->m_ishover);
     delete e;
@@ -100,44 +101,44 @@ TEST_F(Ut_ProgrammerItemWidget, initMark)
 TEST_F(Ut_ProgrammerItemWidget, themetypechanged)
 {
     ProgrammerItemWidget *m_programmerItemWidget = new ProgrammerItemWidget("WORD");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_programmerItemWidget->themetypechanged(2);
     EXPECT_EQ(m_programmerItemWidget->m_label->palette().color(QPalette::ColorGroup::Active, QPalette::ColorRole::Text).name(),
               "#ffffff");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_programmerItemWidget->themetypechanged(1);
     EXPECT_EQ(m_programmerItemWidget->m_label->palette().color(QPalette::ColorGroup::Active, QPalette::ColorRole::Text).name(),
               "#000000");
 
     ProgrammerItemWidget *m_programmerItemWidget1 = new ProgrammerItemWidget("Circular shift", 50, ":/assets/images/dark/icon_as_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_programmerItemWidget1->themetypechanged(2);
     EXPECT_EQ(m_programmerItemWidget1->m_normalUrl, ":/assets/images/dark/icon_ro_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_programmerItemWidget1->themetypechanged(1);
     EXPECT_EQ(m_programmerItemWidget1->m_normalUrl, ":/assets/images/light/icon_ro_normal.svg");
 
     ProgrammerItemWidget *m_programmerItemWidget2 = new ProgrammerItemWidget("Arithmetic shift", 50, ":/assets/images/dark/icon_as_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_programmerItemWidget2->themetypechanged(2);
     EXPECT_EQ(m_programmerItemWidget2->m_normalUrl, ":/assets/images/dark/icon_as_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_programmerItemWidget2->themetypechanged(1);
     EXPECT_EQ(m_programmerItemWidget2->m_normalUrl, ":/assets/images/light/icon_as_normal.svg");
 
     ProgrammerItemWidget *m_programmerItemWidget3 = new ProgrammerItemWidget("Logical shift", 50, ":/assets/images/dark/icon_as_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_programmerItemWidget3->themetypechanged(2);
     EXPECT_EQ(m_programmerItemWidget3->m_normalUrl, ":/assets/images/dark/icon_ls_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_programmerItemWidget3->themetypechanged(1);
     EXPECT_EQ(m_programmerItemWidget3->m_normalUrl, ":/assets/images/light/icon_ls_normal.svg");
 
     ProgrammerItemWidget *m_programmerItemWidget4 = new ProgrammerItemWidget("Rotate through carry circular shift", 50, ":/assets/images/dark/icon_as_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_programmerItemWidget4->themetypechanged(2);
     EXPECT_EQ(m_programmerItemWidget4->m_normalUrl, ":/assets/images/dark/icon_rc_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_programmerItemWidget4->themetypechanged(1);
     EXPECT_EQ(m_programmerItemWidget4->m_normalUrl, ":/assets/images/light/icon_rc_normal.svg");
 
@@ -160,14 +161,14 @@ TEST_F(Ut_ProgrammerItemWidget, paintEvent)
 {
     ProgrammerItemWidget *m_programmerItemWidget = new ProgrammerItemWidget("WORD");
     QPaintEvent *event = new QPaintEvent(m_programmerItemWidget->rect());
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::UnknownType);
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::LightType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::UnknownType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::LightType);
     m_programmerItemWidget->m_ispress = true;
     m_programmerItemWidget->m_ishover = false;
     m_programmerItemWidget->paintEvent(event);
     m_programmerItemWidget->update();
     ProgrammerItemWidget *m_programmerItemWidget1 = new ProgrammerItemWidget("Circular shift", 50, ":/assets/images/dark/icon_as_normal.svg");
-    DGuiApplicationHelper::instance()->setThemeType(DGuiApplicationHelper::ColorType::DarkType);
+    DTK_SET_THEME_TYPE(DGuiApplicationHelper::ColorType::DarkType);
     m_programmerItemWidget1->m_isMarkHide = false;
     m_programmerItemWidget1->m_isshift = true;
     m_programmerItemWidget1->m_ispress = false;

--- a/tests/src/views/ut_prolistdelegate.cpp
+++ b/tests/src/views/ut_prolistdelegate.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -87,7 +87,7 @@ TEST_F(Ut_ProListDelegate, paintnofocus)
     Stub stub;
     stub.set(ADDR(ProListView, hasFocus), stub_focus_prolistdelegateF);
     QStyleOptionViewItem option;
-    option.init(m_prolistview1);
+    option.initFrom(m_prolistview1);
     Stub stub1;
     stub1.set(ADDR(ProListView, currentIndex), stub_index_prolistdelegate3);
     m_proListDelegate1->m_themeType = 0;

--- a/tests/src/views/ut_simplelistdelegate.cpp
+++ b/tests/src/views/ut_simplelistdelegate.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -153,7 +153,7 @@ TEST_F(Ut_SimpleListDelegate, paintnofocus)
     Stub stub;
     stub.set(ADDR(SimpleListView, hasFocus), stub_focus_simpledelegateF);
     QStyleOptionViewItem option;
-    option.init(m_simplelistview);
+    option.initFrom(m_simplelistview);
     QWidget wid;
     wid.setFixedWidth(10);
     option.widget = &wid;
@@ -180,7 +180,7 @@ TEST_F(Ut_SimpleListDelegate, paint1nofocus)
     Stub stub;
     stub.set(ADDR(SimpleListView, hasFocus), stub_focus_simpledelegateF);
     QStyleOptionViewItem option;
-    option.init(m_simplelistview);
+    option.initFrom(m_simplelistview);
     QWidget wid;
     wid.setFixedWidth(10);
     option.widget = &wid;

--- a/tests/src/views/ut_simplelistmodel.cpp
+++ b/tests/src/views/ut_simplelistmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -49,7 +49,8 @@ TEST_F(Ut_SimpleListModel, updataList1)
     m_simpleListModel->updataList("2", 500, true);
     m_simpleListModel->updataList("3", 500, false);
     m_simpleListModel->updataList("3x3", 500, false);
-    EXPECT_EQ(m_simpleListModel->m_expressionList.count(), 500);
+    // sci=true: delete(499)+insert=500; sci=false: delete(0)+replace=499; sci=false: replace=499
+    EXPECT_EQ(m_simpleListModel->m_expressionList.count(), 499);
 }
 
 TEST_F(Ut_SimpleListModel, updataList2)

--- a/tests/src/widgets/ut_expressionbar.cpp
+++ b/tests/src/widgets/ut_expressionbar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -120,11 +120,11 @@ TEST_F(Ut_ExpressionBar, enterEqualEvent)
     m_expressionBar->findChild<InputEdit *>()->setText("1＋");
     historicalLinkageIndex his;
     his.linkageTerm = 0;
-    his.linkageValue = 3;
+    his.linkageValue = QString::number(3);
     his.linkedItem = 1;
     m_expressionBar->m_hisLink.append(his);
     his.linkageTerm = 1;
-    his.linkageValue = 3;
+    his.linkageValue = QString::number(3);
     his.linkedItem = 2;
     m_expressionBar->m_hisLink.append(his);
     m_expressionBar->m_hisRevision = -1;
@@ -292,13 +292,13 @@ TEST_F(Ut_ExpressionBar, clearLinkageCache)
     ExpressionBar *m_expressionBar = new ExpressionBar;
     historicalLinkageIndex his;
     his.linkageTerm = 0;
-    his.linkageValue = 3;
+    his.linkageValue = QString::number(3);
     his.linkedItem = 1;
     m_expressionBar->m_hisLink.append(his);
     m_expressionBar->clearLinkageCache("1＋2＝3", true);
     historicalLinkageIndex his1;
     his1.linkageTerm = 0;
-    his1.linkageValue = 3;
+    his1.linkageValue = QString::number(3);
     his1.linkedItem = 1;
     m_expressionBar->m_hisLink.append(his1);
     m_expressionBar->m_hisLink.last().linkedItem = -1;
@@ -313,7 +313,7 @@ TEST_F(Ut_ExpressionBar, settingLinkage)
     ExpressionBar *m_expressionBar = new ExpressionBar;
     historicalLinkageIndex his;
     his.linkageTerm = 0;
-    his.linkageValue = 3;
+    his.linkageValue = QString::number(3);
     his.linkedItem = 1;
     m_expressionBar->m_hisLink.append(his);
     m_expressionBar->m_hisRevision = 0;
@@ -321,7 +321,7 @@ TEST_F(Ut_ExpressionBar, settingLinkage)
     EXPECT_EQ(m_expressionBar->m_hisLink.count(), 1);
     m_expressionBar->m_hisLink.clear();
     his.linkageTerm = 1;
-    his.linkageValue = 3;
+    his.linkageValue = QString::number(3);
     his.linkedItem = 0;
     m_expressionBar->m_hisLink.append(his);
     m_expressionBar->m_hisRevision = 0;
@@ -364,7 +364,7 @@ TEST_F(Ut_ExpressionBar, cancelLink)
     m_expressionBar->findChild<InputEdit *>()->setText("1＋2");
     historicalLinkageIndex his;
     his.linkageTerm = 0;
-    his.linkageValue = 3;
+    his.linkageValue = QString::number(3);
     his.linkedItem = 1;
     m_expressionBar->m_hisLink.append(his);
     m_expressionBar->m_hisRevision = 1;

--- a/tests/src/widgets/ut_proexpressionbar.cpp
+++ b/tests/src/widgets/ut_proexpressionbar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -502,8 +502,7 @@ TEST_F(Ut_ProexpressionBar, selectedPartDelete)
     select1.selected = "1an";
     m_proexpressionBar->m_inputEdit->setSelection(select1);
     QString sRegNum = "[a-z]";
-    QRegExp rx;
-    rx.setPattern(sRegNum);
+    QRegularExpression rx(sRegNum);
     m_proexpressionBar->selectedPartDelete(rx);
     EXPECT_EQ(m_proexpressionBar->findChild<InputEdit *>()->text(), "1,122");
 

--- a/tests/test-prj-running.sh
+++ b/tests/test-prj-running.sh
@@ -1,28 +1,32 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-builddir=build
+builddir=build-test
 reportdir=build-ut
-rm -r $builddir
-rm -r ../$builddir
-rm -r $reportdir
-rm -r ../$reportdir
-mkdir ../$builddir
-mkdir ../$reportdir
-cd ../$builddir
-#编译
+rm -r $builddir 2>/dev/null || true
+rm -r ../$builddir 2>/dev/null || true
+rm -r $reportdir 2>/dev/null || true
+rm -r ../$reportdir 2>/dev/null || true
+mkdir ../$builddir 2>/dev/null || true
+mkdir ../$reportdir 2>/dev/null || true
+cd ../$builddir || exit 1
+
+# 编译
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SAFETYTEST_ARG="CMAKE_SAFETYTEST_ARG_ON" ..
 make -j8
-#生成asan日志和ut测试xml结果
+
+# 创建报告目录
+mkdir -p report
+
+# 运行测试并生成 XML 结果
 ./tests/deepin-calculator-test --gtest_output=xml:./report/report_deepin-calculator.xml
 
 workdir=$(cd ../$(dirname $0)/$builddir; pwd)
 
-mkdir -p report
-#统计代码覆盖率并生成html报告
+# 统计代码覆盖率并生成 HTML 报告
 lcov -d $workdir -c -o ./coverage.info
 
 lcov --extract ./coverage.info '*/src/*' -o ./coverage.info
@@ -32,9 +36,12 @@ lcov --remove ./coverage.info '*/tests/*' -o ./coverage.info
 genhtml -o ./html ./coverage.info
 
 mv ./html/index.html ./html/cov_deepin-calculator.html
-#对asan、ut、代码覆盖率结果收集至指定文件夹
-cp -r html ../$reportdir/
-cp -r report ../$reportdir/
-cp -r asan*.log* ../$reportdir/asan_deepin-calculator.log
+
+# 收集 ASAN、UT、代码覆盖率结果至指定文件夹
+cp -r html ../$reportdir/ 2>/dev/null || true
+cp -r report ../$reportdir/ 2>/dev/null || true
+cp asan*.log* ../$reportdir/asan_deepin-calculator.log 2>/dev/null || true
+
+echo "测试完成！报告已生成到: ../$reportdir"
 
 exit 0


### PR DESCRIPTION
Fix multiple assertion failures caused by Qt6 stricter bounds checking on QChar, QString, QList and qBound operations.

Fix multiple Qt6 migration issues: QChar multi-byte literal overflow, QString out-of-bounds access, QList index overflow, and negative position in mid() calls. Add bounds guards across expressionbar, sciexpressionbar, proexpressionbar, simplelistmodel and simplelistdelegate.

Log: 修复Qt6迁移导致的单元测试崩溃问题
Influence: 修复后391个单元测试全部运行完毕无崩溃，此前因
QChar/QList/QString断言失败导致测试进程直接终止。